### PR TITLE
feat: prevent options being generated

### DIFF
--- a/src/prefabs/factories/component.ts
+++ b/src/prefabs/factories/component.ts
@@ -1,17 +1,23 @@
 import type { IdentityRecordBy } from '../../type-utils';
 import type { PrefabComponent, PrefabReference } from '../types/component';
 
+function isNotNullEntry <T, X>(entry: [T, X]): entry is [T, NonNullable<X>] {
+  const [, option] = entry;
+  return option !== null;
+}
+
 type RequiredAttrs = Omit<PrefabComponent, 'name' | 'descendants'>;
 type UnresolvedAttributes = IdentityRecordBy<
   RequiredAttrs,
   'options',
-  [string]
+  [string],
+  'nullable'
 >;
 
 const resolveAttributes = (attrs: UnresolvedAttributes): RequiredAttrs => {
-  const options = Object.entries(attrs.options).map(([key, option]) =>
-    option(key),
-  );
+  const options = Object.entries(attrs.options)
+    .filter(isNotNullEntry)
+    .map(([key, option]) => option(key));
 
   return {
     ...attrs,

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -4,10 +4,14 @@ type Singleton<T> = T extends Array<any> ? T[0] : T;
 type Identities<T, Args extends Array<any>> = {
   [K in keyof T]: Identity<T[K], Args>;
 };
-type IdentityRecords<T, Args extends Array<any>> = {
-  [K in keyof T]: Record<string, Identity<Singleton<T[K]>, Args>>;
+type IdentityRecords<T, Args extends Array<any>, Features> = {
+  [K in keyof T]: Record<
+    string,
+    Features extends 'nullable'
+      ? Identity<Singleton<T[K]>, Args> | null
+      : Identity<Singleton<T[K]>, Args>
+  >;
 };
-// type Singletons<T> = { [K in keyof T]: Singleton<T[K]> };
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 export type IdentityBy<T, K extends keyof T, ARGS extends Array<any>> = Omit<
@@ -15,8 +19,12 @@ export type IdentityBy<T, K extends keyof T, ARGS extends Array<any>> = Omit<
   K
 > &
   Identities<Pick<T, K>, ARGS>;
+
+type IdentityFeatures = 'nullable' | ''
+
 export type IdentityRecordBy<
   T,
   K extends keyof T,
   Args extends Array<any>,
-> = Omit<T, K> & IdentityRecords<Pick<T, K>, Args>;
+  Features extends IdentityFeatures = '',
+> = Omit<T, K> & IdentityRecords<Pick<T, K>, Args, Features>;

--- a/tests/prefabs/factories/component.test.ts
+++ b/tests/prefabs/factories/component.test.ts
@@ -1,14 +1,45 @@
 import test from 'tape';
 import { component, partial } from '../../../src/prefabs/factories/component';
-import { variable, showIfTrue } from '../../../src/prefabs/factories/options';
+import {
+  variable,
+  showIfTrue,
+  toggle,
+} from '../../../src/prefabs/factories/options';
 
 test('component builds empty component', (t) => {
-  const result = component('Text', {options: {}}, []);
+  const result = component('Text', { options: {} }, []);
   const expected = {
     name: 'Text',
     options: [],
     descendants: [],
-    type: 'COMPONENT'
+    type: 'COMPONENT',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('component ignores null options', (t) => {
+  const result = component(
+    'Text',
+    {
+      options: {
+        shouldNotExist: null,
+        shouldExist: toggle('ShouldExist', { value: false }),
+      },
+    },
+    [],
+  );
+  const expected = {
+    name: 'Text',
+    options: [{
+      label: 'ShouldExist',
+      key: 'shouldExist',
+      type: 'TOGGLE',
+      value: false
+    }],
+    descendants: [],
+    type: 'COMPONENT',
   };
 
   t.deepEqual(result, expected);


### PR DESCRIPTION
 - by changing an option to be null you can prevent it from
   showing in the final output.

 - this can be useful if you want to suppress a component option
   in a shared component from appearing in all prefabs