### PR TITLE
fix: added helper folder with helper functions

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './typecheck';

--- a/src/helpers/typecheck.ts
+++ b/src/helpers/typecheck.ts
@@ -1,0 +1,7 @@
+import { PrefabReference, PrefabComponent, PrefabPartial } from "../prefabs/types/component"
+
+export const isPrefabPartial = (reference: PrefabReference): 
+  reference is PrefabPartial => reference.type === 'PARTIAL'
+
+export const isPrefabComponent = (reference: PrefabReference): 
+reference is PrefabComponent => reference.type === 'COMPONENT'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './prefabs';
+export * from './helpers';


### PR DESCRIPTION
I've added a helper folder and created two helper functions for the pro-coder to use in the material-ui-component-set.

This allows the user to check if the prefab.structure[0].type can be either a partial, or a component.
This will resolve the current errors that are in the MUI set.