### PR TITLE
feat: add authprofile factory option

### DIFF
--- a/src/prefabs/factories/options/authenticationProfile.ts
+++ b/src/prefabs/factories/options/authenticationProfile.ts
@@ -1,0 +1,29 @@
+import {
+  PrefabComponentOption,
+  ValueDefault,
+  ValueRef,
+} from '../../types/options';
+
+type OptionProducer = (key: string) => PrefabComponentOption;
+
+// typescript issue #36981
+// Omit is currently desctructive to union/extended types see
+// So we have to Omit each variant as a work around
+type RedundantKeys = 'type' | 'key' | 'label';
+type Attributes =
+  | Omit<ValueDefault, RedundantKeys>
+  | Omit<ValueRef, RedundantKeys>;
+
+const defaultAttributes = {
+  value: [],
+};
+
+export const authenticationProfile =
+  (label: string, attrs: Attributes): OptionProducer =>
+  (key) => ({
+    ...defaultAttributes,
+    ...attrs,
+    key,
+    type: 'AUTHENTICATION_PROFILE',
+    label,
+  });

--- a/src/prefabs/factories/options/index.ts
+++ b/src/prefabs/factories/options/index.ts
@@ -1,4 +1,5 @@
 export { action } from './action';
+export { authenticationProfile } from './authenticationProfile';
 export { actionInputObjects } from './actionInputObjects';
 export { color } from './color';
 export { endpoint } from './endpoint';

--- a/tests/prefabs/factories/authenticationProfile.test.ts
+++ b/tests/prefabs/factories/authenticationProfile.test.ts
@@ -1,0 +1,50 @@
+import test from 'tape';
+import { authenticationProfile } from '../../../src/prefabs/factories/options/authenticationProfile';
+
+test('authenticationProfile builds option', (t) => {
+  const result = authenticationProfile('AuthProfile label', {
+    value: '1234abcd5678efgh',
+  })('authProfile');
+
+  const expected = {
+    value: '1234abcd5678efgh',
+    key: 'authProfile',
+    type: 'AUTHENTICATION_PROFILE',
+    label: 'AuthProfile label',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('authenticationProfile builds options with string value', (t) => {
+  const result = authenticationProfile('Authentication Profile label', {
+    value: '',
+    configuration: {
+      condition: {
+        type: 'SHOW',
+        option: 'model',
+        comparator: 'EQ',
+        value: '',
+      },
+    },
+  })('authProfile');
+
+  const expected = {
+    value: '',
+    label: 'Authentication Profile label',
+    key: 'authProfile',
+    type: 'AUTHENTICATION_PROFILE',
+    configuration: {
+      condition: {
+        type: 'SHOW',
+        option: 'model',
+        comparator: 'EQ',
+        value: '',
+      },
+    },
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});


### PR DESCRIPTION
Created a authenticationProfile factory options, wrote tests and yarn linked this in the component-set. Works as intended