### PR TITLE
fix: updated action factory option

### DIFF
--- a/src/prefabs/factories/options/action.ts
+++ b/src/prefabs/factories/options/action.ts
@@ -14,14 +14,9 @@ type Attributes =
   | Omit<ValueDefault, RedundantKeys>
   | Omit<ValueRef, RedundantKeys>;
 
-const defaultAttributes = {
-  value: [],
-};
-
 export const action =
   (label: string, attrs: Attributes): OptionProducer =>
   (key) => ({
-    ...defaultAttributes,
     ...attrs,
     key,
     type: 'ACTION',

--- a/tests/prefabs/factories/action.test.ts
+++ b/tests/prefabs/factories/action.test.ts
@@ -49,3 +49,41 @@ test('actionInputObjects builds options with configuration', (t) => {
   t.deepEqual(result, expected);
   t.end();
 });
+
+test('action builds options with ref. The OptionProducer allows only one value', (t) => {
+  const result = action('Action has a ref', {
+    ref: {
+      value: '#actionId',
+    },
+    configuration: {
+      apiVersion: 'v1',
+      condition: {
+        type: 'SHOW',
+        option: 'linkType',
+        comparator: 'EQ',
+        value: 'action',
+      },
+    },
+  })('action');
+
+  const expected = {
+    ref: {
+      value: '#actionId',
+    },
+    label: 'Action has a ref',
+    key: 'action',
+    type: 'ACTION',
+    configuration: {
+      apiVersion: 'v1',
+      condition: {
+        type: 'SHOW',
+        option: 'linkType',
+        comparator: 'EQ',
+        value: 'action',
+      },
+    },
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});


### PR DESCRIPTION
I have updated the action factory option. In the component-set, it should only allow one 'value'.
I have removed the required value: [] from the OptionProducer and wrote tests to show that when a ref: { value: '#TheValue'} is present, it will only allow one value. More value's will fail the test.