### PR TITLE
feat: allow option categories in wrapper and component factories

### DIFF
--- a/src/prefabs/factories/component.ts
+++ b/src/prefabs/factories/component.ts
@@ -1,7 +1,5 @@
 import type { IdentityRecordBy } from '../../type-utils';
-import { LinkedOptionProducer } from '../types';
 import type { PrefabComponent, PrefabReference } from '../types/component';
-import type { OptionCategory } from '../types/options';
 
 function isNotNullEntry<T, X>(entry: [T, X]): entry is [T, NonNullable<X>] {
   const [, option] = entry;
@@ -41,39 +39,6 @@ export const partial = (): PrefabReference => ({
   type: 'PARTIAL',
   partialId: '',
 });
-
-export type WrapperAttrs = {
-  label?: string;
-  optionCategories?: OptionCategory[];
-  options?: Record<string, LinkedOptionProducer>;
-};
-
-/**
- * Create a wrapper prefab
- *
- * @returns
- */
-export const wrapper = (
-  attrs: WrapperAttrs,
-  descendants: PrefabReference[],
-): PrefabReference => {
-  const labelField = attrs.label ? { label: attrs.label } : {};
-  const options = Object.entries(attrs.options || {}).map(([key, linked]) =>
-    linked(key),
-  );
-  const optionCategories =
-    attrs.optionCategories && attrs.optionCategories.length !== 0
-      ? { optionCategories: attrs.optionCategories }
-      : {};
-
-  return {
-    type: 'WRAPPER',
-    ...labelField,
-    ...optionCategories,
-    options,
-    descendants,
-  };
-};
 
 /**
  * Create a component prefab

--- a/src/prefabs/factories/index.ts
+++ b/src/prefabs/factories/index.ts
@@ -1,3 +1,5 @@
-export { component, wrapper, partial } from './component';
+export { component } from './component';
+export { wrapper } from './wrapper';
+export { partial } from './partial';
 export { prefab, BeforeCreateArgs } from './prefab';
 export * from './options';

--- a/src/prefabs/factories/partial.ts
+++ b/src/prefabs/factories/partial.ts
@@ -1,0 +1,11 @@
+import type { PrefabReference } from '../types/component';
+
+/**
+ * Create a partial prefab
+ *
+ * @returns
+ */
+export const partial = (): PrefabReference => ({
+  type: 'PARTIAL',
+  partialId: '',
+});

--- a/src/prefabs/factories/wrapper.ts
+++ b/src/prefabs/factories/wrapper.ts
@@ -1,0 +1,35 @@
+import type { PrefabReference } from '../types/component';
+import type { LinkedOptionProducer, OptionCategory } from '../types/options';
+
+export type WrapperAttrs = {
+  label?: string;
+  optionCategories?: OptionCategory[];
+  options?: Record<string, LinkedOptionProducer>;
+};
+
+/**
+ * Create a wrapper prefab
+ *
+ * @returns
+ */
+export const wrapper = (
+  attrs: WrapperAttrs,
+  descendants: PrefabReference[],
+): PrefabReference => {
+  const labelField = attrs.label ? { label: attrs.label } : {};
+  const options = Object.entries(attrs.options || {}).map(([key, linked]) =>
+    linked(key),
+  );
+  const optionCategories =
+    attrs.optionCategories && attrs.optionCategories.length !== 0
+      ? { optionCategories: attrs.optionCategories }
+      : {};
+
+  return {
+    type: 'WRAPPER',
+    ...labelField,
+    ...optionCategories,
+    options,
+    descendants,
+  };
+};

--- a/src/prefabs/types/component.ts
+++ b/src/prefabs/types/component.ts
@@ -1,5 +1,6 @@
 import { PrefabAction } from './actions';
 import {
+  OptionCategory,
   PrefabComponentOption,
   PrefabWrapperLinkedOption,
   PrefabComponentStyle,
@@ -16,6 +17,7 @@ export interface PrefabWrapper {
   type: 'WRAPPER';
   label?: string;
   descendants: PrefabReference[];
+  optionCategories?: OptionCategory[];
   options: PrefabWrapperLinkedOption[];
 }
 
@@ -26,6 +28,7 @@ export interface PrefabComponent {
   actions?: PrefabAction[];
   descendants: PrefabReference[];
   name: string;
+  optionCategories?: OptionCategory[];
   options: PrefabComponentOption[];
   $afterCreate?: Hook[];
   $afterDelete?: Hook[];

--- a/src/prefabs/types/options.ts
+++ b/src/prefabs/types/options.ts
@@ -1,5 +1,11 @@
 export type ValueConfig = Record<string, unknown>;
 
+export type OptionCategory = {
+  label: string;
+  expanded?: boolean;
+  members: string[];
+};
+
 export interface PrefabComponentOptionBase {
   label: string;
   key: string;
@@ -27,7 +33,7 @@ export interface PrefabWrapperLinkedOption extends PrefabComponentOptionBase {
     ref: {
       componentId: string;
       optionId: string;
-    }
+    };
   };
 }
 

--- a/tests/prefabs/factories/category.test.ts
+++ b/tests/prefabs/factories/category.test.ts
@@ -1,0 +1,116 @@
+import test from 'tape';
+import { component, wrapper } from '../../../src/prefabs/factories';
+import { linked, variable } from '../../../src/prefabs/factories/options';
+
+test('an option category in a wrapper should accept options', (t) => {
+  const result = wrapper(
+    {
+      label: 'Wrapper label',
+      optionCategories: [
+        {
+          label: 'Category label',
+          expanded: true,
+          members: ['linkedOption1', 'linkedOption2'],
+        },
+      ],
+      options: {
+        linkedOption1: linked({
+          label: 'My linked label',
+          value: { ref: { componentId: '#1', optionId: '#1' } },
+        }),
+        linkedOption2: linked({
+          label: 'My linked label',
+          value: { ref: { componentId: '#1', optionId: '#2' } },
+        }),
+      },
+    },
+    [
+      component(
+        'Alert',
+        {
+          ref: {
+            id: '#1',
+          },
+          optionCategories: [
+            { label: 'Category label', expanded: true, members: ['option1'] },
+          ],
+          options: {
+            option1: variable('Value', {
+              ref: {
+                id: '#1',
+              },
+            }),
+            option2: variable('Value', {
+              ref: {
+                id: '#2',
+              },
+            }),
+          },
+        },
+        [],
+      ),
+    ],
+  );
+
+  const expected = {
+    type: 'WRAPPER',
+    label: 'Wrapper label',
+    optionCategories: [
+      {
+        label: 'Category label',
+        expanded: true,
+        members: ['linkedOption1', 'linkedOption2'],
+      },
+    ],
+    options: [
+      {
+        key: 'linkedOption1',
+        label: 'My linked label',
+        value: { ref: { componentId: '#1', optionId: '#1' } },
+        type: 'LINKED_OPTION',
+      },
+      {
+        key: 'linkedOption2',
+        label: 'My linked label',
+        value: { ref: { componentId: '#1', optionId: '#2' } },
+        type: 'LINKED_OPTION',
+      },
+    ],
+    descendants: [
+      {
+        ref: {
+          id: '#1',
+        },
+        name: 'Alert',
+        optionCategories: [
+          { label: 'Category label', expanded: true, members: ['option1'] },
+        ],
+        options: [
+          {
+            ref: {
+              id: '#1',
+            },
+            type: 'VARIABLE',
+            label: 'Value',
+            key: 'option1',
+            value: [],
+          },
+          {
+            ref: {
+              id: '#2',
+            },
+            type: 'VARIABLE',
+            label: 'Value',
+            key: 'option2',
+            value: [],
+          },
+        ],
+        descendants: [],
+        type: 'COMPONENT',
+      },
+    ],
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});

--- a/tests/prefabs/factories/component.test.ts
+++ b/tests/prefabs/factories/component.test.ts
@@ -1,9 +1,5 @@
 import test from 'tape';
-import {
-  component,
-  partial,
-  wrapper,
-} from '../../../src/prefabs/factories/component';
+import { component } from '../../../src/prefabs/factories/component';
 import {
   variable,
   showIfTrue,
@@ -47,64 +43,6 @@ test('component ignores null options', (t) => {
     ],
     descendants: [],
     type: 'COMPONENT',
-  };
-
-  t.deepEqual(result, expected);
-  t.end();
-});
-
-test('partial builds empty partial', (t) => {
-  const result = partial();
-  const expected = {
-    type: 'PARTIAL',
-    partialId: '',
-  };
-
-  t.deepEqual(result, expected);
-  t.end();
-});
-
-test('builds a wrapper prefab', (t) => {
-  const result = wrapper({}, []);
-  const expected = {
-    type: 'WRAPPER',
-    options: [],
-    descendants: [],
-  };
-
-  t.deepEqual(result, expected);
-  t.end();
-});
-
-test('builds a wrapper prefab with descendants', (t) => {
-  const result = wrapper({}, [component('ROW', { options: {} }, [])]);
-  const expected = {
-    type: 'WRAPPER',
-    options: [],
-    descendants: [
-      { name: 'ROW', options: [], descendants: [], type: 'COMPONENT' },
-    ],
-  };
-
-  t.deepEqual(result, expected);
-  t.end();
-});
-
-test('builds a wrapper prefab with descendants and inner wrapper', (t) => {
-  const result = wrapper({}, [
-    component('ROW', { options: {} }, [wrapper({}, [])]),
-  ]);
-  const expected = {
-    type: 'WRAPPER',
-    options: [],
-    descendants: [
-      {
-        name: 'ROW',
-        options: [],
-        descendants: [{ type: 'WRAPPER', options: [], descendants: [] }],
-        type: 'COMPONENT',
-      },
-    ],
   };
 
   t.deepEqual(result, expected);

--- a/tests/prefabs/factories/partial.test.ts
+++ b/tests/prefabs/factories/partial.test.ts
@@ -1,0 +1,14 @@
+import test from 'tape';
+
+import { partial } from '../../../src/prefabs/factories/partial';
+
+test('partial builds empty partial', (t) => {
+  const result = partial();
+  const expected = {
+    type: 'PARTIAL',
+    partialId: '',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});

--- a/tests/prefabs/factories/wrapper.test.ts
+++ b/tests/prefabs/factories/wrapper.test.ts
@@ -1,0 +1,51 @@
+import test from 'tape';
+
+import { component } from '../../../src/prefabs/factories/component';
+import { wrapper } from '../../../src/prefabs/factories/wrapper';
+
+test('builds a wrapper prefab', (t) => {
+  const result = wrapper({}, []);
+  const expected = {
+    type: 'WRAPPER',
+    options: [],
+    descendants: [],
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('builds a wrapper prefab with descendants', (t) => {
+  const result = wrapper({}, [component('ROW', { options: {} }, [])]);
+  const expected = {
+    type: 'WRAPPER',
+    options: [],
+    descendants: [
+      { name: 'ROW', options: [], descendants: [], type: 'COMPONENT' },
+    ],
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('builds a wrapper prefab with descendants and inner wrapper', (t) => {
+  const result = wrapper({}, [
+    component('ROW', { options: {} }, [wrapper({}, [])]),
+  ]);
+  const expected = {
+    type: 'WRAPPER',
+    options: [],
+    descendants: [
+      {
+        name: 'ROW',
+        options: [],
+        descendants: [{ type: 'WRAPPER', options: [], descendants: [] }],
+        type: 'COMPONENT',
+      },
+    ],
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});


### PR DESCRIPTION
* Add the possibility to add `optionCategories` to the attributes of the `wrapper()` and `component()` factories