### PR TITLE
feat: add prefabconfiguration for prefabs and wrote test

### DIFF
--- a/src/prefabs/types/options.ts
+++ b/src/prefabs/types/options.ts
@@ -27,7 +27,7 @@ export interface PrefabWrapperLinkedOption extends PrefabComponentOptionBase {
     ref: {
       componentId: string;
       optionId: string;
-    }
+    };
   };
 }
 
@@ -61,6 +61,13 @@ export type PrefabComponentStyle = {
     textTransform?: string;
   };
 };
+
+export interface PrefabConfiguration {
+  options?: Record<string, OptionProducer>;
+  style?: PrefabComponentStyle;
+  ref?: { id: string };
+}
+
 export type OptionProducer = (key: string) => PrefabComponentOption;
 export type LinkedOptionProducer = (key: string) => PrefabWrapperLinkedOption;
 

--- a/tests/prefabs/factories/component.test.ts
+++ b/tests/prefabs/factories/component.test.ts
@@ -10,6 +10,8 @@ import {
   toggle,
   reconfigure,
 } from '../../../src/prefabs/factories/options';
+import { PrefabConfiguration } from '../../../src/prefabs/types/options';
+import { PrefabReference } from '../../../src/prefabs/types/component';
 
 test('component builds empty component', (t) => {
   const result = component('Text', { options: {} }, []);
@@ -202,6 +204,36 @@ test('component is a data table with a "reconfigure" option', (t) => {
         type: 'RECONFIGURE',
       },
     ],
+    descendants: [],
+    type: 'COMPONENT',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('component makes use of PrefabConfiguration interface', (t) => {
+  // Create prefab logic equal to mui-component-set
+  const componentItem = (
+    config: PrefabConfiguration,
+    descendants: PrefabReference[] = [],
+  ) => {
+    const options = { ...config.options };
+    const style = config.style ? { ...config.style } : undefined;
+    const ref = config.ref ? { ...config.ref } : undefined;
+
+    return component('Carousel', { options, style, ref }, descendants);
+  };
+
+  const result = componentItem(
+    { ref: { id: '#component' }, style: { overwrite: { fontSize: '14' } } },
+    [],
+  );
+  const expected = {
+    name: 'Carousel',
+    options: [],
+    style: { overwrite: { fontSize: '14' } },
+    ref: { id: '#component' },
     descendants: [],
     type: 'COMPONENT',
   };


### PR DESCRIPTION
Moved 'Configuration' of prefabs from the component-set to the SDK as an interface, so it can be used throughout the component-set. 
Also wrote a test to show that the prefab options work without configuration within the prefab.