### PR TITLE
feat: add modelAndRelation factory option

### DIFF
--- a/src/prefabs/factories/options/index.ts
+++ b/src/prefabs/factories/options/index.ts
@@ -18,6 +18,7 @@ export { icon } from './icon';
 export { filter } from './filter';
 export { linked } from './linked';
 export { model } from './model';
+export { modelAndRelation } from './modelAndRelation';
 export { property } from './property';
 export { reconfigure } from './reconfigure';
 

--- a/src/prefabs/factories/options/modelAndRelation.ts
+++ b/src/prefabs/factories/options/modelAndRelation.ts
@@ -1,0 +1,30 @@
+import { PartialBy } from '../../../type-utils';
+import {
+  PrefabComponentOption,
+  ValueDefault,
+  ValueRef,
+} from '../../types/options';
+
+type OptionProducer = (key: string) => PrefabComponentOption;
+
+// typescript issue #36981
+// Omit is currently desctructive to union/extended types see
+// So we have to Omit each variant as a work around
+type RedundantKeys = 'type' | 'key' | 'label';
+type Attributes =
+  | PartialBy<Omit<ValueDefault, RedundantKeys>, 'value'>
+  | Omit<ValueRef, RedundantKeys>;
+
+const defaultAttributes = {
+  value: '',
+};
+
+export const modelAndRelation =
+  (label: string, attrs: Attributes = {}): OptionProducer =>
+  (key) => ({
+    ...defaultAttributes,
+    ...attrs,
+    key,
+    type: 'MODEL_AND_RELATION',
+    label,
+  });

--- a/tests/prefabs/factories/font.test.ts
+++ b/tests/prefabs/factories/font.test.ts
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { font } from '../../../src/prefabs/factories/options/index';
+import { font, modelAndRelation } from '../../../src/prefabs/factories/options';
 
 test('font builds variable option with a value', (t) => {
   const result = font('Font', { value: ['Body1'] })('font');
@@ -41,6 +41,20 @@ test('font builds variable option with a configuration', (t) => {
         value: true,
       },
     },
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('modelAndRelation builds variable option', (t) => {
+  const result = modelAndRelation('Model', { value: '' })('model');
+
+  const expected = {
+    type: 'MODEL_AND_RELATION',
+    label: 'Model',
+    key: 'model',
+    value: '',
   };
 
   t.deepEqual(result, expected);

--- a/tests/prefabs/factories/font.test.ts
+++ b/tests/prefabs/factories/font.test.ts
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { font, modelAndRelation } from '../../../src/prefabs/factories/options';
+import { font } from '../../../src/prefabs/factories/options/index';
 
 test('font builds variable option with a value', (t) => {
   const result = font('Font', { value: ['Body1'] })('font');
@@ -41,20 +41,6 @@ test('font builds variable option with a configuration', (t) => {
         value: true,
       },
     },
-  };
-
-  t.deepEqual(result, expected);
-  t.end();
-});
-
-test('modelAndRelation builds variable option', (t) => {
-  const result = modelAndRelation('Model', { value: '' })('model');
-
-  const expected = {
-    type: 'MODEL_AND_RELATION',
-    label: 'Model',
-    key: 'model',
-    value: '',
   };
 
   t.deepEqual(result, expected);

--- a/tests/prefabs/factories/modelAndRelation.test.ts
+++ b/tests/prefabs/factories/modelAndRelation.test.ts
@@ -1,0 +1,46 @@
+import test from 'tape';
+import {
+  modelAndRelation,
+  showIf,
+} from '../../../src/prefabs/factories/options';
+
+test('modelAndRelation builds variable option', (t) => {
+  const result = modelAndRelation('Model', {
+    value: '',
+  })('model');
+
+  const expected = {
+    type: 'MODEL_AND_RELATION',
+    label: 'Model',
+    key: 'model',
+    value: '',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});
+
+test('modelAndRelation builds variable option with configuration', (t) => {
+  const result = modelAndRelation('Model', {
+    value: '',
+    configuration: { condition: showIf('model', 'EQ', '') },
+  })('model');
+
+  const expected = {
+    type: 'MODEL_AND_RELATION',
+    label: 'Model',
+    key: 'model',
+    value: '',
+    configuration: {
+      condition: {
+        type: 'SHOW',
+        option: 'model',
+        comparator: 'EQ',
+        value: '',
+      },
+    },
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});


### PR DESCRIPTION
Added a modelAndRelation factory option to the sdk, because it isn't available yet