### PR TITLE
fix: add number type to linked configuration options

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
   "types": "build/index.d.ts",
   "author": "Benjamin Kagia <benjamin.kagia@bettyblocks.com>",
   "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bettyblocks/component-sdk.git"
-  },
+  "repository": "https://github.com/bettyblocks/component-sdk.git",
+  
   "engines": {
     "node": "^16.11.1"
   },

--- a/src/prefabs/types/options.ts
+++ b/src/prefabs/types/options.ts
@@ -48,7 +48,7 @@ export type PrefabWrapperLinkedOptionConfiguration = {
     type: 'SHOW' | 'HIDE';
     option: string;
     comparator: 'EQ';
-    value: string | boolean;
+    value: string | boolean | number;
   };
 };
 export interface PrefabWrapperLinkedOption

--- a/tests/prefabs/factories/linked.test.ts
+++ b/tests/prefabs/factories/linked.test.ts
@@ -34,3 +34,43 @@ test('linked builds a linked option with a value ref', (t) => {
   t.deepEqual(result, expected);
   t.end();
 });
+
+test('linked builds an option where value contains a number', (t) => {
+  const result = linked({
+    label: 'Form title example',
+    configuration: {
+      condition: {
+        type: 'SHOW',
+        option: 'optionWithButtonGroup',
+        comparator: 'EQ',
+        value: 1,
+      },
+    },
+    value: {
+      ref: { componentId: '#tabs', optionId: '#tabsOptionWithButtonGroup' },
+    },
+  })('linkedTextComponentExample');
+
+  const expected = {
+    value: {
+      ref: {
+        componentId: '#tabs',
+        optionId: '#tabsOptionWithButtonGroup',
+      },
+    },
+    configuration: {
+      condition: {
+        type: 'SHOW',
+        option: 'optionWithButtonGroup',
+        comparator: 'EQ',
+        value: 1,
+      },
+    },
+    key: 'linkedTextComponentExample',
+    type: 'LINKED_OPTION',
+    label: 'Form title example',
+  };
+
+  t.deepEqual(result, expected);
+  t.end();
+});


### PR DESCRIPTION
The value of the wrapperConfigurationOptions now allows a number type. 