### PR TITLE
feat: add disabledNames to property option to disable properties

### DIFF
--- a/src/prefabs/types/options.ts
+++ b/src/prefabs/types/options.ts
@@ -139,6 +139,7 @@ export interface PrefabComponentOptionBase {
     dataType?: string;
     dependsOn?: string;
     disabled?: boolean;
+    disabledNames?: string[];
     mediaType?: 'IMAGE' | 'VIDEO';
     modal?: {
       type: 'MODEL_AND_PROPERTIES';

--- a/tests/prefabs/factories/component.test.ts
+++ b/tests/prefabs/factories/component.test.ts
@@ -233,6 +233,7 @@ test('component is a data table with "reconfigure" options', (t) => {
                 allowedKinds: ['TEXT', 'URL'],
                 allowedClickThroughKinds: ['BELONGS_TO'],
                 allowedSplitButtonKinds: ['TEXT', 'URL'],
+                disabledNames: ['id', 'created_at', 'updated_at'],
                 pushToWrapper: {
                   name: 'WrapperLabel',
                   condition: {
@@ -281,6 +282,7 @@ test('component is a data table with "reconfigure" options', (t) => {
               allowedKinds: ['TEXT', 'URL'],
               allowedClickThroughKinds: ['BELONGS_TO'],
               allowedSplitButtonKinds: ['TEXT', 'URL'],
+              disabledNames: ['id', 'created_at', 'updated_at'],
               pushToWrapper: {
                 name: 'WrapperLabel',
                 condition: {


### PR DESCRIPTION
When using a dateTime property option for an input component, we don't want the business technologist to select the updated_at and created_at properties, because you cannot override them.